### PR TITLE
fix: fixing issues with invoking class constructor without new

### DIFF
--- a/lib/Elements/index.js
+++ b/lib/Elements/index.js
@@ -329,4 +329,4 @@ class Elements extends Base {
   }
 }
 
-module.exports = Elements();
+module.exports = new Elements();

--- a/lib/Entities/index.js
+++ b/lib/Entities/index.js
@@ -28,4 +28,4 @@ class Entities {
   }
 }
 
-module.exports = Entities();
+module.exports = new Entities();

--- a/lib/Input/index.js
+++ b/lib/Input/index.js
@@ -354,4 +354,4 @@ class Input extends Base {
   }
 }
 
-module.exports = Input();
+module.exports = new Input();


### PR DESCRIPTION
- The constructor of `Entities`, `Elements` and `Input` classes was getting invoked without `new` and hence an error was being thrown.